### PR TITLE
Only unmaximize when currently maximized.

### DIFF
--- a/doc/maximizer.txt
+++ b/doc/maximizer.txt
@@ -46,10 +46,10 @@ Maximizer has only one command: >
 It is meant to be mapped in many ways by the user himself. See
 |maximizer-configuration| to get some examples.
 
-Upon the first invocation of the command, Vim-Maximizer saves dimensions and
-positions of all windows in the current tab, and then it performs maximization
-of the active window. The second time the command is invoked, Maximizer
-restores all windows to the previously saved positions and the cycle repeats.
+When the current window is not in maximized state, Vim-Maximizer saves
+dimensions and positions of all windows in the current tab, and then it
+performs maximization of the active window. The second time the command is
+invoked, Maximizer restores all windows to the previously saved positions.
 
 ----------------------------------------------------------------------------
 3. Configuration                                     *maximizer-configuration*

--- a/plugin/maximizer.vim
+++ b/plugin/maximizer.vim
@@ -24,8 +24,16 @@ let g:loaded_vim_maximizer = 1
 
 command! -nargs=0 -range MaximizerToggle :call s:maximizer_toggle()
 
+fun! s:others_minimized()
+    for w in range(1, winnr('$'))
+        if w != winnr() && winheight(w) > &winminheight && winwidth(w) > &winminwidth
+            return 0
+        endif
+    endfor
+    return 1
+endfun
 fun! s:maximizer_toggle()
-    if exists('t:maximizer_sizes')
+    if exists('t:maximizer_sizes') && s:others_minimized()
         silent! exe t:maximizer_sizes
         if t:maximizer_sizes != winrestcmd()
             wincmd =


### PR DESCRIPTION
I find the plugin useful, but it's hard for me to remember the state the plugin is in, especially if the maximization was done some time ago and I have modified the window layout in the meantime. I think it's better to extend the logic so that demaximization is only performed when the current window is still in maximized state. When other windows' sizes have been increased in the meantime, re-maximize instead of re-applying the stored, outdated window layout.
